### PR TITLE
Extra method to get ip. Using UDP datagram

### DIFF
--- a/src/main/java/org/chris/portmapper/router/AbstractRouter.java
+++ b/src/main/java/org/chris/portmapper/router/AbstractRouter.java
@@ -21,8 +21,10 @@
 package org.chris.portmapper.router;
 
 import java.io.IOException;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 import org.slf4j.Logger;
@@ -53,11 +55,16 @@ public abstract class AbstractRouter implements IRouter {
     public String getLocalHostAddress() throws RouterException {
         logger.debug("Get IP of localhost");
 
-        final InetAddress localHostIP = getLocalHostAddressFromSocket();
+        InetAddress localHostIP = getLocalHostAddressFromSocket();
 
         // We do not want an address like 127.0.0.1
         if (localHostIP.getHostAddress().startsWith("127.")) {
-            throw new RouterException("Only found an address that begins with '127.' when retrieving IP of localhost");
+            localHostIP = getLocalHostAddressFromDatagramSocket();
+
+            if (localHostIP.getHostAddress().startsWith("127.")) {
+                throw new RouterException(
+                        "Only found an address that begins with '127.' when retrieving IP of localhost");
+            }
         }
 
         return localHostIP.getHostAddress();

--- a/src/main/java/org/chris/portmapper/router/AbstractRouter.java
+++ b/src/main/java/org/chris/portmapper/router/AbstractRouter.java
@@ -112,6 +112,28 @@ public abstract class AbstractRouter implements IRouter {
         return localHostIP;
     }
 
+    /**
+     * Get the ip of the local host by attempting to send a datagram to an address that may not exist in a port that
+     * probably has nothing listening
+     *
+     * @return the ip of the local host.
+     * @throws RouterException
+     */
+    private InetAddress getLocalHostAddressFromDatagramSocket() throws RouterException {
+        try (final DatagramSocket socket = new DatagramSocket()) {
+            // What matters for IP and port is that they are valid
+            // The main process here happens in C code but it appears to work in linux and windows
+            socket.connect(InetAddress.getByName("255.255.255.0"), 0);
+            return socket.getLocalAddress();
+        } catch (final UnknownHostException e) {
+            // Should never happen
+            throw new RouterException("Error with Unknown host. Should have been impossible", e);
+        } catch (final SocketException e) {
+            // Should never happen
+            throw new RouterException("Socket failed when trying to get local IP address", e);
+        }
+    }
+
     @Override
     public void close() {
         this.disconnect();


### PR DESCRIPTION
This method to try getting the local IP address seem to work correctly on linux and windows, even though for windows, the current method works just fine.

The way this code works depends on java's `protected native void connect0(InetAddress address, int port)` native `C` code java accessible through `java.net.PlainDatagramSocketImpl`.
The best way I was able to find to use such method by making a datagram (UDP packet) and send it to nowhere reachable.